### PR TITLE
Add wtd function for worktree deletion

### DIFF
--- a/zsh/functions.zsh
+++ b/zsh/functions.zsh
@@ -62,3 +62,43 @@ wts() {
   # 自動的に worktree に移動
   cd "$worktree_path"
 }
+
+# Worktree Delete - wts で作成した worktree を削除
+wtd() {
+  local current_path main_repo
+
+  # Gitリポジトリ内かチェック
+  if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+    echo "❌ エラー: Git リポジトリ内で実行してください"
+    return 1
+  fi
+
+  # ワークツリーか判定（メインリポジトリでないことを確認）
+  local git_dir=$(git rev-parse --git-dir 2>/dev/null)
+  if [[ "$git_dir" == ".git" ]]; then
+    echo "❌ エラー: ここはワークツリーではありません"
+    return 1
+  fi
+
+  # wts で作成したワークツリーかチェック
+  current_path=$(pwd)
+  if [[ "$current_path" != ~/Projects/worktrees/* ]]; then
+    echo "❌ エラー: このワークツリーは wts で作成されていません"
+    return 1
+  fi
+
+  # メインリポジトリのパスを取得
+  main_repo=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
+
+  # メインリポジトリに移動
+  cd "$main_repo" || {
+    echo "❌ エラー: 元のリポジトリに移動できませんでした"
+    return 1
+  }
+
+  # ワークツリーを削除
+  git worktree remove "$current_path" || return 1
+
+  # 成功メッセージ
+  echo "✅ Worktree を削除しました: $current_path"
+}


### PR DESCRIPTION
## 概要
`wts` 関数で作成したワークツリーを安全に削除する `wtd` 関数を追加しました。

## 主な変更点
- `zsh/functions.zsh` に `wtd` 関数を追加（40行）

## 機能詳細

### 対象
- `~/Projects/worktrees/` 配下のワークツリーのみ削除可能（wts連携）

### 動作
1. ワークツリー内で `wtd` を実行
2. Git環境チェック（リポジトリ内か、ワークツリーか）
3. wts作成チェック（パス検証）
4. 元のリポジトリに自動移動
5. `git worktree remove` 実行
6. 成功メッセージ表示

### 安全機能
- Git標準のエラーチェックに依存
- 4種類の明確なエラーメッセージ（絵文字付き）
- 未コミット変更がある場合はgitが自動的にエラーを出して保護

### 使用例
```bash
# worktree内で実行
wtd

# → 元のリポジトリに戻り、worktreeが削除される
# → ブランチは残る（必要に応じて手動で git branch -d）
```

## テスト項目
- [x] wts作成のワークツリーで実行（変更なし） → 成功
- [x] メインリポジトリで実行 → エラー表示
- [x] Git外で実行 → エラー表示
- [x] ~/Projects/worktrees/ 外のワークツリーで実行 → エラー表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)